### PR TITLE
Update jquery.hashchange.js

### DIFF
--- a/src/jquery.hashchange.js
+++ b/src/jquery.hashchange.js
@@ -56,6 +56,12 @@
   };
 
   $.fn.hashchange = function(options) {
+    if (options === "prevHash" && arguments.length > 1)
+    {
+      $.hashchange.prevHash = arguments[1];
+      return this;
+    }
+
     // options array passed
     if (Object.prototype.toString.call(options) === "[object Array]") {
       for (var i = options.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Allow a change or reset to another previous hash so hashchange can fire or not fire when needed.

I didn't change the dist code, just the source.  I'm sure there is a better way, but this was a quick fix for what I needed.  I was trying to force a hashchange to run again.  So my solution was to clear out the previous hash and then trigger.

``` javascript
$(window).hashchange("prevHash", "");
$(window).trigger("hashchange");
```
